### PR TITLE
Add skeleton brand risk scoring script

### DIFF
--- a/brand-shield/README.md
+++ b/brand-shield/README.md
@@ -1,0 +1,17 @@
+# Brand Shield Skeleton
+
+이 디렉터리는 브랜드 손상 방지 대시보드의 최소 예시 코드입니다.
+
+## 구성
+- `index.js`: 샘플 리뷰/매출 데이터를 이용하여 간단한 리스크 점수를 계산합니다.
+- `data/`: 샘플 데이터(JSON)
+- `test.js`: 데이터 로드 확인용 테스트
+
+## 실행
+```
+cd brand-shield
+npm test   # 테스트 실행
+npm start  # 리스크 점수 계산
+```
+
+패키지 설치 없이 Node.js만으로 동작합니다.

--- a/brand-shield/data/reviews.json
+++ b/brand-shield/data/reviews.json
@@ -1,0 +1,24 @@
+[
+  {
+    "review_id": "r1",
+    "store_id": "s1",
+    "channel": "naver",
+    "rating": 1,
+    "text": "음식이 너무 짰어요",
+    "lang": "ko",
+    "created_at": "2024-06-01T12:00:00Z",
+    "reply_from_store": null,
+    "media": []
+  },
+  {
+    "review_id": "r2",
+    "store_id": "s1",
+    "channel": "kakao",
+    "rating": 4,
+    "text": "친절했습니다",
+    "lang": "ko",
+    "created_at": "2024-06-02T12:00:00Z",
+    "reply_from_store": null,
+    "media": []
+  }
+]

--- a/brand-shield/data/sales.json
+++ b/brand-shield/data/sales.json
@@ -1,0 +1,5 @@
+[
+  {"store_id":"s1","date":"2024-05-30","sales_net":100000,"orders":100,"cancellations":2,"discount_amount":5000,"cohort_flags":{"new_menu":false,"promo":false}},
+  {"store_id":"s1","date":"2024-05-31","sales_net":95000,"orders":95,"cancellations":1,"discount_amount":4000,"cohort_flags":{"new_menu":false,"promo":false}},
+  {"store_id":"s1","date":"2024-06-01","sales_net":60000,"orders":60,"cancellations":3,"discount_amount":6000,"cohort_flags":{"new_menu":false,"promo":false}}
+]

--- a/brand-shield/index.js
+++ b/brand-shield/index.js
@@ -1,0 +1,35 @@
+import fs from 'fs';
+import path from 'path';
+
+// Load sample data
+const dataDir = path.join(process.cwd(), 'data');
+const reviews = JSON.parse(fs.readFileSync(path.join(dataDir, 'reviews.json')));
+const sales = JSON.parse(fs.readFileSync(path.join(dataDir, 'sales.json')));
+
+// Simple risk computation: negative sentiment + sales drop
+function computeRisk(storeId) {
+  const storeReviews = reviews.filter(r => r.store_id === storeId);
+  const storeSales = sales.filter(s => s.store_id === storeId);
+
+  // Sentiment: proportion of ratings <=2
+  const negCount = storeReviews.filter(r => r.rating <= 2).length;
+  const sentiment = storeReviews.length ? negCount / storeReviews.length : 0;
+
+  // Sales anomaly: compare last day vs avg of previous days
+  let salesScore = 0;
+  if (storeSales.length > 1) {
+    const last = storeSales[storeSales.length - 1].sales_net;
+    const prevAvg = storeSales.slice(0, -1).reduce((acc, s) => acc + s.sales_net, 0) / (storeSales.length - 1);
+    salesScore = prevAvg ? Math.max(0, (prevAvg - last) / prevAvg) : 0;
+  }
+
+  // Combine and scale 0-100
+  const risk = (0.5 * sentiment + 0.5 * salesScore) * 100;
+  return Math.round(risk);
+}
+
+// Compute risk per store
+const storeIds = [...new Set(reviews.map(r => r.store_id))];
+for (const id of storeIds) {
+  console.log(`Store ${id} risk: ${computeRisk(id)}`);
+}

--- a/brand-shield/package.json
+++ b/brand-shield/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "brand-shield",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js",
+    "test": "node test.js"
+  },
+  "description": "Skeleton brand risk dashboard sample code."
+}

--- a/brand-shield/test.js
+++ b/brand-shield/test.js
@@ -1,0 +1,13 @@
+import assert from 'assert';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const dataDir = path.join(__dirname, 'data');
+const reviews = JSON.parse(fs.readFileSync(path.join(dataDir, 'reviews.json')));
+
+// Test that reviews load correctly
+assert.ok(reviews.length > 0, 'Should load reviews');
+
+console.log('Tests passed');


### PR DESCRIPTION
## Summary
- add brand-shield skeleton with sample review and sales data
- implement simple risk score script and data loading test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7c600464083229ff993813a08e4cf